### PR TITLE
[core] Fix ReDoS Vulnerability in commonFramework-*.js by Replacing Vulnerable Regex

### DIFF
--- a/client/commonFramework/bindings.js
+++ b/client/commonFramework/bindings.js
@@ -21,10 +21,6 @@ window.common = (function(global) {
   };
 
   common.init.push(function($) {
-      /**
-   * 安全替代 `.replace(/#+$/, '')`，用于去除 URL 或字符串末尾多余的 #
-   * 线性处理，无正则回溯风险，适用于高安全要求场景
-   */
     function stripTrailingHashes(url) {
       let i = url.length - 1;
       while (i >= 0 && url[i] === '#') i--;

--- a/client/commonFramework/bindings.js
+++ b/client/commonFramework/bindings.js
@@ -21,6 +21,15 @@ window.common = (function(global) {
   };
 
   common.init.push(function($) {
+      /**
+   * 安全替代 `.replace(/#+$/, '')`，用于去除 URL 或字符串末尾多余的 #
+   * 线性处理，无正则回溯风险，适用于高安全要求场景
+   */
+    function stripTrailingHashes(url) {
+      let i = url.length - 1;
+      while (i >= 0 && url[i] === '#') i--;
+      return url.slice(0, i + 1);
+    }
 
     var $marginFix = $('.innerMarginFix');
     $marginFix.css('min-height', $marginFix.height());
@@ -179,10 +188,9 @@ window.common = (function(global) {
     });
 
     $('#search-issue').on('click', function() {
-      var queryIssue = window.location.href
-        .toString()
-        .split('?')[0]
-        .replace(/(#*)$/, '');
+      var queryIssue = stripTrailingHashes(
+        window.location.href.toString().split('?')[0]
+      );
       window.open(
         'https://github.com/freecodecampchina/freecodecamp.cn/issues?q=' +
         'is:issue is:all ' +

--- a/client/commonFramework/init.js
+++ b/client/commonFramework/init.js
@@ -46,13 +46,13 @@ window.common = (function(global) {
   };
 
   common.replaceFormActionAttr = function replaceFormAction(value) {
-    return value.replace(/<form[^>]*>/, function(val) {
+    return value.replace(/<form(?!<form)[^>]*>/, function(val) {
       return val.replace(/action(\s*?)=/, 'fccfaa$1=');
     });
   };
 
   common.replaceFccfaaAttr = function replaceFccfaaAttr(value) {
-    return value.replace(/<form[^>]*>/, function(val) {
+    return value.replace(/<form(?!<form)[^>]*>/, function(val) {
       return val.replace(/fccfaa(\s*?)=/, 'action$1=');
     });
   };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "lint-json": "npm run lint-server && npm run lint-challenges && npm run lint-resources && npm run lint-utils",
     "test-challenges": "babel-node seed/test-challenges.js | tap-spec",
     "pretest": "npm run lint",
-    "test": "npm run test-challenges"
+    "test": "npm run test-challenges",
+    "test-redos": "mocha test/commonFramework/bindings.test.js"
   },
   "license": "(BSD-3-Clause AND CC-BY-SA-4.0)",
   "dependencies": {

--- a/public/js/commonFramework-2c9795240d.js
+++ b/public/js/commonFramework-2c9795240d.js
@@ -51,13 +51,13 @@ window.common = function(e) {
     }
     ,
     a.replaceFormActionAttr = function(e) {
-        return e.replace(/<form[^>]*>/, function(e) {
+        return e.replace(/<form(?!<form)[^>]*>/, function(e) {
             return e.replace(/action(\s*?)=/, "fccfaa$1=")
         })
     }
     ,
     a.replaceFccfaaAttr = function(e) {
-        return e.replace(/<form[^>]*>/, function(e) {
+        return e.replace(/<form(?!<form)[^>]*>/, function(e) {
             return e.replace(/fccfaa(\s*?)=/, "action$1=")
         })
     }

--- a/test/commonFramework/bindings.test.js
+++ b/test/commonFramework/bindings.test.js
@@ -1,0 +1,45 @@
+// test/bindings.test.js
+const { expect } = require('chai');
+const { performance } = require('perf_hooks');
+
+// 安全替代函数
+function stripTrailingHashes(url) {
+  let i = url.length - 1;
+  while (i >= 0 && url[i] === '#') i--;
+  return url.slice(0, i + 1);
+}
+
+// 模拟原版逻辑（用于对比测试）
+function originalReplace(url) {
+  return url.replace(/#+$/, '');
+}
+
+describe('✅ stripTrailingHashes replacement test', function () {
+  this.timeout(10000); // 最多允许10秒运行
+
+  it('should match behavior of original regex for normal cases', () => {
+    const cases = [
+      ["https://a.com/page#", "https://a.com/page"],
+      ["https://a.com/page###", "https://a.com/page"],
+      ["https://a.com/page#section", "https://a.com/page#section"],
+      ["https://a.com/page#section#", "https://a.com/page#section"],
+      ["https://a.com/page", "https://a.com/page"],
+    ];
+
+    for (const [input, expected] of cases) {
+      expect(stripTrailingHashes(input)).to.equal(expected);
+      expect(stripTrailingHashes(input)).to.equal(originalReplace(input));
+    }
+  });
+
+  it('should not hang on malicious long string input', () => {
+    const attack = '#'.repeat(100000) + '@';
+    const testUrl = 'https://a.com/' + attack;
+    const t0 = performance.now();
+    const result = stripTrailingHashes(testUrl);
+    const t1 = performance.now();
+    const duration = (t1 - t0) / 1000;
+    console.log(`⏱️ safeReplace() 执行耗时：${duration.toFixed(3)} s`);
+    expect(duration).to.be.lessThan(1); // 应该非常快（毫秒级）
+  });
+});


### PR DESCRIPTION
### Steps to reproduce

Hello,

I am writing to report a potential Regular Expression Denial of Service (ReDoS) vulnerability or Inefficient Regular Expression in the project. When using specially crafted input strings in the context, it may lead to extremely high CPU usage, application freezing, or denial of service attacks.

**Location of Issue:**

The vulnerability is related to a regular expression used in the following validation file, which may result in significantly prolonged execution times under certain conditions.

https://github.com/FreeCodeCampChina/freecodecamp.cn/blob/b09a3a0dec1fa0b0620601a705ff2e9b97564f97/public/js/commonFramework-2c9795240d.js#L54

Line 54 in [`b09a3a0`](https://github.com/FreeCodeCampChina/freecodecamp.cn/blob/b09a3a0dec1fa0b0620601a705ff2e9b97564f97/public/js/commonFramework-2c9795240d.js#L54)

https://github.com/FreeCodeCampChina/freecodecamp.cn/blob/b09a3a0dec1fa0b0620601a705ff2e9b97564f97/public/js/commonFramework-2c9795240d.js#L60

Line 60 in [`b09a3a0`](https://github.com/FreeCodeCampChina/freecodecamp.cn/blob/b09a3a0dec1fa0b0620601a705ff2e9b97564f97/public/js/commonFramework-2c9795240d.js#L60)

| Line | Code |
|------|------|
|  54  | `` `${"demo": "${e.replace(/<form[^>]*>/, function(e) {"}` `` |
|  60  | `` `${"demo": "${e.replace(/<form[^>]*>/, function(e) {"}` `` |

**PoC Files and Comparisons:**

https://gist.github.com/cecechen04/f60d9b812234e748503e033ab9de56ed

To evaluate the performance of this inefficient regular expression matching with varying input contents, the following commands can be executed within every PoC folder:

```bash
$ npm install # Install necessary dependencies for the minimal proof of concept environment.
$ time node poc.js # Run the script with maliciously constructed string and record the running time.
$ time node normal_string.js # Run the script with normal strings of same length and record the running time.
```
In the most severe case, on my machine, the maliciously crafted string took the following time, and caused CPU usage to reach 99% during program execution:
```bash
real    0m3.419s  
user    0m3.390s  
sys     0m0.010s
```
However, a normal string of the same length only took the following time:
```bash
real    0m0.052s  
user    0m0.030s  
sys     0m0.010s
```
This reveals a significant efficiency problem with the regular expression used in the program under certain conditions.

Proposed Solution: 

A simple strategy could be to limit the length of the string being matched by the regular expression, thereby preventing excessive time consumption during regex matching. To completely avoid the issue, the pathological part of the regular expression that causes catastrophic backtracking should be modified.

Background Information: 
Here are some real-world examples of issues caused by ReDoS vulnerabilities:

1. **In 2019**, Cloudflare experienced a service disruption lasting approximately 27 minutes due to a ReDoS vulnerability that allowed crafted input to overwhelm regex processing, resulting in significant performance degradation and temporary service outage (source: [Cloudflare Incident Report](https://blog.cloudflare.com/details-of-the-cloudflare-outage-on-july-2-2019/)).

2. **Stack Overflow** was affected by a ReDoS vulnerability in 2016, causing multiple instances of service degradation and temporary outages of up to 34 minutes during peak traffic periods due to inefficient regular expression patterns (source: [Stack Overflow Incident Report](http://stackstatus.net/post/147710624694/outage-postmortem-july-20-2016)).
Thank you for your attention to this matter. Your evaluation and response to this potential security concern would be greatly appreciated.

Best regards,

Search keywords: ReDoS
